### PR TITLE
Fix for user’s not having expected roles

### DIFF
--- a/src/auth-middleware.coffee
+++ b/src/auth-middleware.coffee
@@ -57,7 +57,7 @@ module.exports = (robot) ->
 
   robot.listenerMiddleware (context, next, done) ->
     opts    = context.listener.options
-    reqUser = context.response.message.user
+    reqUser = robot.brain.userForName(context.response.message.user.name)
     reqRoom = context.response.message.room
     reqMsg  = context.response.message.text
     action  = successAction

--- a/src/auth-middleware.coffee
+++ b/src/auth-middleware.coffee
@@ -78,7 +78,7 @@ module.exports = (robot) ->
       if opts.rooms != undefined 
         if reqRoom not in opts.rooms
           action = 'Rejecting (room)'
-          authFail context, "#{action} '#{reqUser.name}: #{reqMsg}' -- use this room: #{opts.room}"
+          authFail context, "#{action} '#{reqUser.name}: #{reqMsg}' -- use this room: #{opts.rooms}"
       if opts.roles != undefined
         if robot.auth.hasRole(reqUser, opts.roles) is false
           action = 'Rejecting (role)'

--- a/src/auth-middleware.coffee
+++ b/src/auth-middleware.coffee
@@ -78,7 +78,7 @@ module.exports = (robot) ->
       if opts.rooms != undefined 
         if reqRoom not in opts.rooms
           action = 'Rejecting (room)'
-          authFail context, "#{action} '#{reqUser.name}: #{reqMsg}' -- use this room: #{opts.rooms}"
+          authFail context, "#{action} '#{reqUser.name}: #{reqMsg}' -- use this room: #{reqRoom}"
       if opts.roles != undefined
         if robot.auth.hasRole(reqUser, opts.roles) is false
           action = 'Rejecting (role)'


### PR DESCRIPTION
The user has no roles object because it is the message
user instead of the user stored in the brain with
the roles associated with it.

To recreate the bug give your user admin role and
role a command role (ex. Foo). Limit a command to
foo.  At line 83 in your code:
``` robot.auth.hasRole(reqUser, opts.roles)```
was always evaluating to false because the user
Passed into the hasRole never had roles on it.

Hubot-Auth expects the user passed into that
function to have roles.

For reference please read code in hubot-auth at
Line 120
https://github.com/hubot-scripts/hubot-auth/blob/master/src/auth.coffee#L120